### PR TITLE
Fix for malformed q strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "supertest-fetch": "^1.2.2",
     "ts-node": "^8.0.2",
     "tslint": "^5.12.1",
-    "typescript": "^3.4.5"
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "ajv": "^6.9.1",

--- a/src/bodyParsers/MultiPartFormDataParser.ts
+++ b/src/bodyParsers/MultiPartFormDataParser.ts
@@ -11,13 +11,14 @@ export default class MultiPartFormDataParser implements BodyParser {
     }
 
     parseReq(req: http.IncomingMessage, _res: http.ServerResponse, done: Callback<void>): void {
-        const parser = new IncomingForm();
+        const options: MultipartFormDataOptions = {};
         if (this._options.maxFileSize) {
-            parser.maxFileSize = this._options.maxFileSize;
+            options.maxFileSize = this._options.maxFileSize;
         }
         if (this._options.uploadDir) {
-            parser.uploadDir = this._options.uploadDir;
+            options.uploadDir = this._options.uploadDir;
         }
+        const parser = new IncomingForm(options);
         parser.parse(req, (_err: any, _fields: any, files: any) => {
             if (_err) {
                 return done(_err);

--- a/src/controllers/loadControllers.ts
+++ b/src/controllers/loadControllers.ts
@@ -48,7 +48,7 @@ export function loadControllersSync(
                     const indexFolder = controllerName.slice(0, -(ext.length + basename.length + 1));
                     result[indexFolder] = result[indexFolder] || mod;
                 }
-            } catch(err) {
+            } catch(err: any) {
                 throw new Error(`Could not load controller '${fullPath}': ${err.message}`);
             }
             return result;

--- a/src/core/exegesisRunner.ts
+++ b/src/core/exegesisRunner.ts
@@ -204,7 +204,7 @@ export default async function generateExegesisRunner<T>(
                                     context
                                 });
                             }
-                        } catch(err) {
+                        } catch(err: any) {
                             err.status = err.status || 500;
                             throw err;
                         }
@@ -218,7 +218,7 @@ export default async function generateExegesisRunner<T>(
 
             return result;
 
-        } catch (err) {
+        } catch (err: any) {
             if(options.autoHandleHttpErrors) {
                 if (options.autoHandleHttpErrors instanceof Function) {
                     return options.autoHandleHttpErrors(err);

--- a/src/oas3/parameterParsers/index.ts
+++ b/src/oas3/parameterParsers/index.ts
@@ -60,7 +60,7 @@ function generateMediaTypeParser(
             } else {
                 return parameterDescriptor.parser.parseString(value);
             }
-        } catch (err) {
+        } catch (err:any) {
             throw new ValidationError({
                 message: `Error parsing parameter ${location.name} of ` +
                     `type ${parameterDescriptor.contentType}: ${err.message}`,

--- a/src/oas3/parameterParsers/simpleStringParser.ts
+++ b/src/oas3/parameterParsers/simpleStringParser.ts
@@ -25,16 +25,24 @@ export function getSimpleStringParser(
 
 // This is for the case where the result is only allowed to be a string.
 export function simpleStringParser(value: string | undefined) : string | string[] | undefined {
-    return !value
-        ? value
-        : decodeURIComponent(value);
+    try{
+        return !value
+          ? value
+          : decodeURIComponent(value);
+    } catch (e) {
+        return  value;
+    }
 }
 
 // This is for the case where the result allowed to be a string or an array.
 export function simpleArrayParser(value: string | undefined) : string[] | undefined {
-    return (value === undefined || value === null)
-        ? value
-        : value.split(',').map(decodeURIComponent);
+    try {
+        return (value === undefined || value === null)
+          ? value
+          : value.split(',').map(decodeURIComponent);
+    } catch (e) {
+        return value ? [value] : undefined;
+    }
 }
 
 export function simpleStringArrayParser(value: string | undefined) : string | string[] | undefined {


### PR DESCRIPTION
# Error 
Na akykolvek query param vyskusaj poslat: %FD. 
Napriklad: http://localhost:9999/v1/categories?query=prechodn%FD&limit=10

# Riesenie
V pripade, ze narazim na error catchnem ho a povodnu hodnotu setnem pre developera. Teda namiesto erroru dostane: "prechodn%FD" a sam musi urcit co s tym. 

